### PR TITLE
Get actual order currency

### DIFF
--- a/Observer/SendPurchaseEvent.php
+++ b/Observer/SendPurchaseEvent.php
@@ -141,7 +141,7 @@ class SendPurchaseEvent implements ObserverInterface
             [
                 'transaction_id' => $order->getIncrementId(),
                 'affiliation' => $order->getStoreName(),
-                'currency' => $invoice->getGlobalCurrencyCode(),
+                'currency' => $order->getOrderCurrencyCode() ?? $invoice->getGlobalCurrencyCode(),
                 'value' => $invoice->getBaseGrandTotal(),
                 'tax' => $invoice->getBaseTaxAmount(),
                 'shipping' => ($this->getPaidShippingCosts($invoice) ?? 0),


### PR DESCRIPTION
This will use the currency of the order instead of the global (store?) currency. Handy if you have stores with different currencies.